### PR TITLE
Workflow did not specify permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Add an explicit top-level `permissions` block in `.github/workflows/rust.yml` so all jobs inherit least-privilege token access by default.

Best fix (without changing workflow behavior): add:

```yaml
permissions:
  contents: read
```

just after the trigger (`on:`) section and before `env:`. This satisfies checkout needs and keeps all jobs read-only unless a future job explicitly overrides permissions.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
